### PR TITLE
[Feat] JWT 인증 수정, 로그인 로직 변경 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	implementation group: 'org.modelmapper', name: 'modelmapper', version: '2.3.9'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/src/main/java/com/HP028/chatbot/chat/domain/Chat.java
+++ b/src/main/java/com/HP028/chatbot/chat/domain/Chat.java
@@ -1,0 +1,30 @@
+package com.HP028.chatbot.chat.domain;
+
+import com.HP028.chatbot.chatroom.domain.ChatRoom;
+import com.HP028.chatbot.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+public class Chat {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String message;
+
+    @JoinColumn(name = "sender_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member sender;
+
+    @JoinColumn(name = "chat_room_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ChatRoom chatRoom;
+
+    private LocalDateTime timestamp;
+
+}

--- a/src/main/java/com/HP028/chatbot/chatroom/domain/ChatRoom.java
+++ b/src/main/java/com/HP028/chatbot/chatroom/domain/ChatRoom.java
@@ -1,0 +1,27 @@
+package com.HP028.chatbot.chatroom.domain;
+
+import com.HP028.chatbot.chat.domain.Chat;
+import com.HP028.chatbot.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "chatRoom")
+    private List<Chat> chats = new ArrayList<>();
+
+    @JoinColumn(name = "owner_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member owner;
+}

--- a/src/main/java/com/HP028/chatbot/common/response/ApiFailStatus.java
+++ b/src/main/java/com/HP028/chatbot/common/response/ApiFailStatus.java
@@ -2,7 +2,6 @@ package com.HP028.chatbot.common.response;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/com/HP028/chatbot/common/response/ApiFailStatus.java
+++ b/src/main/java/com/HP028/chatbot/common/response/ApiFailStatus.java
@@ -8,11 +8,15 @@ import lombok.RequiredArgsConstructor;
 public enum ApiFailStatus {
 
     //400 BAD_REQUEST
-    INVALID_PASSWORD("비밀번호 오류"),
+    SIGN_IN_FAIL("로그인 실패"),
     INVALID_TOKEN_PREFIX("토큰 접두사 오류"),
     DUPLICATED_MEMBER_FIELD("중복된 이메일 혹은 이름입니다"),
 
     //401 UNAUTHORIZED
+    INVALID_TOKEN("유효하지 않은 토큰입니다"),
+    EXPIRED_TOKEN("만료된 토큰입니다"),
+    UNSUPPORTED_TOKEN("지원하지 않는 토큰입니다"),
+    EMPTY_CLAIMS("토큰 클레임이 비어있습니다"),
 
     //403 FORBIDDEN
 

--- a/src/main/java/com/HP028/chatbot/common/response/ApiResponse.java
+++ b/src/main/java/com/HP028/chatbot/common/response/ApiResponse.java
@@ -22,12 +22,11 @@ public class ApiResponse<T> {
                         .build());
     }
 
-    public static ResponseEntity<ApiResponse> fail(String message, HttpStatus httpStatus){
-        return ResponseEntity.status(httpStatus)
-                .body(ApiResponse.builder()
-                        .status(httpStatus.value())
-                        .message(message)
-                        .build());
+    public static ApiResponse fail(String message, HttpStatus httpStatus){
+        return ApiResponse.builder()
+                    .status(httpStatus.value())
+                    .message(message)
+                    .build();
     }
 
 }

--- a/src/main/java/com/HP028/chatbot/config/SecurityConfig.java
+++ b/src/main/java/com/HP028/chatbot/config/SecurityConfig.java
@@ -63,6 +63,9 @@ public class SecurityConfig{
                         .anyRequest().authenticated());
 
         http
+                .addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class);
+
+        http
                 .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration),jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
         //세션 설정

--- a/src/main/java/com/HP028/chatbot/config/jwt/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/HP028/chatbot/config/jwt/CustomAuthenticationEntryPoint.java
@@ -1,5 +1,7 @@
 package com.HP028.chatbot.config.jwt;
 
+import com.HP028.chatbot.common.response.ApiFailStatus;
+import com.HP028.chatbot.common.response.ApiResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -8,38 +10,34 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 
-//@Slf4j(topic = "UNAUTHORIZATION_EXCEPTION_HANDLER")
-//@Component
-//public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
-//    private final HandlerExceptionResolver resolver;
-//
-//    public CustomAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver, ObjectMapper objectMapper) {
-//        this.resolver = resolver;
-//        this.objectMapper = objectMapper;
-//    }
-//
-//    private final ObjectMapper objectMapper;
-//
-//    @Override
-//    public void commence(HttpServletRequest request,
-//                         HttpServletResponse response,
-//                         AuthenticationException authException) throws IOException, ServletException {
-//        log.error("Not Authenticated Request", authException);
-//
-//        ErrorResponseDto errorResponseDto = new ErrorResponseDto(HttpStatus.UNAUTHORIZED.value(), authException.getMessage(), LocalDateTime.now());
-//
-//        String responseBody = objectMapper.writeValueAsString(errorResponseDto);
-//        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-//        response.setStatus(HttpStatus.UNAUTHORIZED.value());
-//        response.setCharacterEncoding("UTF-8");
-//        response.getWriter().write(responseBody);
-//    }
-//}
+@Slf4j(topic = "UNAUTHORIZATION_EXCEPTION_HANDLER")
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException{
+        log.error("Not Authenticated Request", authException);
+//        setResponseMessage(response, ApiFailStatus.INVALID_TOKEN);
+
+    }
+
+    public void setResponseMessage(HttpServletResponse response, ApiFailStatus status) throws IOException {
+        log.error("setResponse");
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ApiResponse apiResponse = ApiResponse.fail(status.getMessage(), HttpStatus.valueOf(response.getStatus()));
+        response.getWriter().println(objectMapper.writeValueAsString(apiResponse));
+    }
+}

--- a/src/main/java/com/HP028/chatbot/config/jwt/CustomUserDetails.java
+++ b/src/main/java/com/HP028/chatbot/config/jwt/CustomUserDetails.java
@@ -1,6 +1,5 @@
 package com.HP028.chatbot.config.jwt;
 
-import com.HP028.chatbot.member.domain.Member;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
@@ -16,11 +15,11 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CustomUserDetails implements UserDetails {
 
-    private final Member member;
+    private final CustomUserInfo member;
 
     @Override
     public String getUsername() {
-        return member.getName();
+        return member.getEmail();
     }
 
     @Override
@@ -59,5 +58,4 @@ public class CustomUserDetails implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
-
 }

--- a/src/main/java/com/HP028/chatbot/config/jwt/CustomUserDetailsService.java
+++ b/src/main/java/com/HP028/chatbot/config/jwt/CustomUserDetailsService.java
@@ -16,8 +16,8 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member member = memberRepository.findByName(username)
+        Member member = memberRepository.findByEmail(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found"));
-        return new CustomUserDetails(member);
+        return new CustomUserDetails(CustomUserInfo.of(member));
     }
 }

--- a/src/main/java/com/HP028/chatbot/config/jwt/CustomUserInfo.java
+++ b/src/main/java/com/HP028/chatbot/config/jwt/CustomUserInfo.java
@@ -1,0 +1,22 @@
+package com.HP028.chatbot.config.jwt;
+
+import com.HP028.chatbot.member.domain.Member;
+import lombok.Getter;
+
+@Getter
+public class CustomUserInfo {
+
+    private String email;
+    private String password;
+    private String role;
+
+    public CustomUserInfo(String email, String password, String role) {
+        this.email = email;
+        this.password = password;
+        this.role = role;
+    }
+
+    public static CustomUserInfo of(Member member) {
+        return new CustomUserInfo(member.getEmail(), member.getPassword(), member.getRole().toString());
+    }
+}

--- a/src/main/java/com/HP028/chatbot/config/jwt/JwtFilter.java
+++ b/src/main/java/com/HP028/chatbot/config/jwt/JwtFilter.java
@@ -1,12 +1,12 @@
 package com.HP028.chatbot.config.jwt;
 
-import com.HP028.chatbot.member.domain.Member;
-import com.HP028.chatbot.member.domain.RoleType;
+import com.HP028.chatbot.common.response.ApiFailStatus;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -18,40 +18,34 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
 
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         String authorization = request.getHeader("Authorization");
 
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
+        if (authorization != null && authorization.startsWith("Bearer ")) {
 
-            System.out.println("Authorization is null or does not start with Bearer");
-            filterChain.doFilter(request, response);
+            String token = authorization.split(" ")[1];
+            ApiFailStatus apiFailStatus = jwtUtil.validateToken(token);
+            if (apiFailStatus == null) {
+                String email = jwtUtil.getUsername(token);
+                String password = "tmppassword";
+                String role = jwtUtil.getRole(token);
 
-            return;
+                CustomUserInfo member = new CustomUserInfo(email, password, role);
+
+                CustomUserDetails customUserDetails = new CustomUserDetails(member);
+
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }else {
+                customAuthenticationEntryPoint.setResponseMessage(response, apiFailStatus);
+            }
+
         }
-
-        String token = authorization.split(" ")[1];
-
-        if (jwtUtil.isExpired(token)) {
-
-            System.out.println("Token is expired");
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        RoleType role = jwtUtil.getRole(token);
-        String name = jwtUtil.getUsername(token);
-        String password = "tmppassword";
-
-        Member member = Member.createTempMember(name, password, role);
-
-        CustomUserDetails customUserDetails = new CustomUserDetails(member);
-
-        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
-
-        SecurityContextHolder.getContext().setAuthentication(authToken);
-
         filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/HP028/chatbot/config/jwt/JwtUtil.java
+++ b/src/main/java/com/HP028/chatbot/config/jwt/JwtUtil.java
@@ -1,16 +1,24 @@
 package com.HP028.chatbot.config.jwt;
 
-import com.HP028.chatbot.member.domain.RoleType;
+import com.HP028.chatbot.common.response.ApiFailStatus;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
 import java.util.Date;
 
 @Component
+@Slf4j
 public class JwtUtil {
 
     private final SecretKey secretKey;
@@ -28,9 +36,9 @@ public class JwtUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
     }
 
-    public RoleType getRole(String token) {
+    public String getRole(String token) {
 
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", RoleType.class);
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
     }
 
     public Boolean isExpired(String token) {
@@ -40,12 +48,48 @@ public class JwtUtil {
 
     public String createJwt(String username, String role) {
 
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime tokenValidity = now.plusSeconds(accessTokenExpTime);
+
         return Jwts.builder()
                 .claim("username", username)
                 .claim("role", role)
-                .issuedAt(new Date(System.currentTimeMillis()))
-                .expiration(new Date(System.currentTimeMillis() + accessTokenExpTime))
+                .issuedAt(Date.from(now.toInstant()))
+                .expiration(Date.from(tokenValidity.toInstant()))
                 .signWith(secretKey)
                 .compact();
+    }
+
+    public ApiFailStatus validateToken(String token) {
+        ApiFailStatus apiFailStatus;
+        try {
+            Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getBody();
+            return null;
+        } catch (io.jsonwebtoken.security.SecurityException e) {
+            log.info("Invalid JWT Token", e);
+            apiFailStatus = ApiFailStatus.INVALID_TOKEN;
+        }catch (MalformedJwtException e){
+            log.info("Malformed JWT Token", e);
+            apiFailStatus = ApiFailStatus.INVALID_TOKEN;
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+            apiFailStatus = ApiFailStatus.EXPIRED_TOKEN;
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+            apiFailStatus = ApiFailStatus.UNSUPPORTED_TOKEN;
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+            apiFailStatus = ApiFailStatus.EMPTY_CLAIMS;
+        }
+        return apiFailStatus;
+    }
+
+    public static String getMemberEmailFromToken() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            return userDetails.getMember().getEmail();
+        }
+        throw new RuntimeException("User not authenticated");
     }
 }

--- a/src/main/java/com/HP028/chatbot/config/jwt/LoginDto.java
+++ b/src/main/java/com/HP028/chatbot/config/jwt/LoginDto.java
@@ -1,11 +1,12 @@
-package com.HP028.chatbot.member.dto;
+package com.HP028.chatbot.config.jwt;
 
 import lombok.Getter;
 
 @Getter
-public class MemberSignInRequest {
+public class LoginDto {
 
     private String email;
 
     private String password;
+
 }

--- a/src/main/java/com/HP028/chatbot/config/jwt/LoginFilter.java
+++ b/src/main/java/com/HP028/chatbot/config/jwt/LoginFilter.java
@@ -1,16 +1,25 @@
 package com.HP028.chatbot.config.jwt;
 
+import com.HP028.chatbot.common.response.ApiFailStatus;
+import com.HP028.chatbot.common.response.ApiSuccessStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.util.StreamUtils;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Iterator;
 
@@ -21,11 +30,25 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final JwtUtil jwtUtil;
 
+    private final ObjectMapper objectMapper;
+
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
 
-        String username = obtainUsername(request);
-        String password = obtainPassword(request);
+        LoginDto loginDto;
+
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            ServletInputStream inputStream = request.getInputStream();
+            String messageBody = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+            loginDto = objectMapper.readValue(messageBody, LoginDto.class);
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        String username = loginDto.getEmail();
+        String password = loginDto.getPassword();
 
         UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);
 
@@ -33,7 +56,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     }
 
     @Override
-    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException {
 
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
 
@@ -46,11 +69,21 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String token = jwtUtil.createJwt(userDetails.getUsername(), role);
 
         response.addHeader("Authorization", "Bearer " + token);
+        LoginResponse loginResponse = new LoginResponse(ApiSuccessStatus.SIGNIN_SUCCESS,userDetails.getUsername());
+        String responseBody = objectMapper.writeValueAsString(loginResponse);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(loginResponse.getStatus());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
     }
 
     @Override
-    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
-
-        response.setStatus(401);
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException {
+        LoginResponse loginResponse = new LoginResponse(HttpStatus.BAD_REQUEST, ApiFailStatus.SIGN_IN_FAIL);
+        String responseBody = objectMapper.writeValueAsString(loginResponse);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(loginResponse.getStatus());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
     }
 }

--- a/src/main/java/com/HP028/chatbot/config/jwt/LoginResponse.java
+++ b/src/main/java/com/HP028/chatbot/config/jwt/LoginResponse.java
@@ -1,0 +1,24 @@
+package com.HP028.chatbot.config.jwt;
+
+import com.HP028.chatbot.common.response.ApiFailStatus;
+import com.HP028.chatbot.common.response.ApiSuccessStatus;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class LoginResponse {
+    private int status;
+    private String message;
+    private String email;
+
+    public LoginResponse(ApiSuccessStatus apiSuccessStatus, String username) {
+        this.status = apiSuccessStatus.getHttpStatus().value();
+        this.message = apiSuccessStatus.getMessage();
+        this.email = username;
+    }
+
+    public LoginResponse(HttpStatus httpStatus, ApiFailStatus apiFailStatus) {
+        this.status = httpStatus.value();
+        this.message = apiFailStatus.getMessage();
+    }
+}

--- a/src/main/java/com/HP028/chatbot/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/HP028/chatbot/exception/GlobalExceptionHandler.java
@@ -19,7 +19,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ApiException.class)
     public ResponseEntity<ApiResponse> handleApiException(ApiException e) {
-        return ApiResponse.fail(e.getMessage(), e.getHttpStatus());
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(ApiResponse.fail(e.getMessage(), e.getHttpStatus()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -29,17 +30,20 @@ public class GlobalExceptionHandler {
         if (message.endsWith(", ")) {
             message = message.substring(0, message.length() - 2);
         }
-        return ApiResponse.fail(message, HttpStatus.BAD_REQUEST);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail(message, HttpStatus.BAD_REQUEST));
     }
 
     @ExceptionHandler(SQLException.class)
     public ResponseEntity<ApiResponse> handleSQLException(SQLException e) {
-        return ApiResponse.fail(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.fail(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse> handleException(Exception e) {
         log.warn("Exception", e);
-        return ApiResponse.fail(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.fail(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/com/HP028/chatbot/member/controller/MemberAuthController.java
+++ b/src/main/java/com/HP028/chatbot/member/controller/MemberAuthController.java
@@ -1,17 +1,14 @@
 package com.HP028.chatbot.member.controller;
 
 import com.HP028.chatbot.common.response.ApiResponse;
-import com.HP028.chatbot.member.dto.MemberSignInRequest;
+import com.HP028.chatbot.config.jwt.JwtUtil;
 import com.HP028.chatbot.member.dto.MemberAuthResponse;
 import com.HP028.chatbot.member.dto.MemberSignUpRequest;
 import com.HP028.chatbot.member.service.MemberAuthService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.HP028.chatbot.common.response.ApiSuccessStatus.*;
 
@@ -29,9 +26,4 @@ public class MemberAuthController {
         return ApiResponse.success(SIGNUP_SUCCESS, response);
     }
 
-    @PostMapping("/sign-in")
-    public ResponseEntity<ApiResponse<MemberAuthResponse>> signIn(@RequestBody MemberSignInRequest request) {
-        MemberAuthResponse response = memberAuthService.signIn(request);
-        return ApiResponse.success(SIGNIN_SUCCESS, response);
-    }
 }

--- a/src/main/java/com/HP028/chatbot/member/controller/MemberAuthController.java
+++ b/src/main/java/com/HP028/chatbot/member/controller/MemberAuthController.java
@@ -5,6 +5,7 @@ import com.HP028.chatbot.member.dto.MemberSignInRequest;
 import com.HP028.chatbot.member.dto.MemberAuthResponse;
 import com.HP028.chatbot.member.dto.MemberSignUpRequest;
 import com.HP028.chatbot.member.service.MemberAuthService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,7 @@ import static com.HP028.chatbot.common.response.ApiSuccessStatus.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/member/auth")
+@Tag(name = "회원 인증 API", description = "회원 가입, 로그인 관련 API")
 public class MemberAuthController {
 
     private final MemberAuthService memberAuthService;

--- a/src/main/java/com/HP028/chatbot/member/domain/Member.java
+++ b/src/main/java/com/HP028/chatbot/member/domain/Member.java
@@ -1,11 +1,16 @@
 package com.HP028.chatbot.member.domain;
 
+import com.HP028.chatbot.chat.domain.Chat;
+import com.HP028.chatbot.chatroom.domain.ChatRoom;
 import com.HP028.chatbot.member.dto.MemberSignUpRequest;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -27,6 +32,12 @@ public class Member {
 
     @Enumerated(EnumType.STRING)
     private RoleType role;
+
+    @OneToMany(mappedBy = "sender")
+    private List<Chat> chats = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<ChatRoom> chatRooms = new ArrayList<>();
 
     public void encodePassword(PasswordEncoder passwordEncoder) {
         password = passwordEncoder.encode(password);

--- a/src/main/java/com/HP028/chatbot/member/domain/Member.java
+++ b/src/main/java/com/HP028/chatbot/member/domain/Member.java
@@ -36,7 +36,7 @@ public class Member {
     @OneToMany(mappedBy = "sender")
     private List<Chat> chats = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "owner")
     private List<ChatRoom> chatRooms = new ArrayList<>();
 
     public void encodePassword(PasswordEncoder passwordEncoder) {

--- a/src/main/java/com/HP028/chatbot/member/service/MemberAuthService.java
+++ b/src/main/java/com/HP028/chatbot/member/service/MemberAuthService.java
@@ -1,9 +1,7 @@
 package com.HP028.chatbot.member.service;
 
 import com.HP028.chatbot.exception.BadRequestException;
-import com.HP028.chatbot.exception.NotFoundException;
 import com.HP028.chatbot.member.domain.Member;
-import com.HP028.chatbot.member.dto.MemberSignInRequest;
 import com.HP028.chatbot.member.dto.MemberAuthResponse;
 import com.HP028.chatbot.member.dto.MemberSignUpRequest;
 import com.HP028.chatbot.member.repository.MemberRepository;
@@ -33,17 +31,5 @@ public class MemberAuthService {
         Member savedMember = memberRepository.save(member);
 
         return modelMapper.map(savedMember, MemberAuthResponse.class);
-    }
-
-    public MemberAuthResponse signIn(MemberSignInRequest request) {
-
-        Member member = memberRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
-
-        if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
-            throw new BadRequestException(INVALID_PASSWORD);
-        }
-
-        return modelMapper.map(member, MemberAuthResponse.class);
     }
 }

--- a/src/main/java/com/HP028/chatbot/member/service/MemberAuthService.java
+++ b/src/main/java/com/HP028/chatbot/member/service/MemberAuthService.java
@@ -23,21 +23,27 @@ public class MemberAuthService {
     private final PasswordEncoder passwordEncoder;
 
     public MemberAuthResponse signUp(MemberSignUpRequest request) {
+
         if (memberRepository.existsByEmail(request.getEmail())){
             throw new BadRequestException(DUPLICATED_MEMBER_FIELD);
         }
+
         Member member = Member.createMember(request);
         member.encodePassword(passwordEncoder);
         Member savedMember = memberRepository.save(member);
+
         return modelMapper.map(savedMember, MemberAuthResponse.class);
     }
 
     public MemberAuthResponse signIn(MemberSignInRequest request) {
+
         Member member = memberRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+
         if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
             throw new BadRequestException(INVALID_PASSWORD);
         }
+
         return modelMapper.map(member, MemberAuthResponse.class);
     }
 }


### PR DESCRIPTION
- JWT에 email만 저장하게 변경
- AuthenticationEntryPoint 구현하여 JWT 관련 Exception Handling
- LoginFilter 내부에서 API응답을 반환하도록 수정
- ApiResponse의 fail 메서드의 반환값이 ResponseEntity<ApiResponse> 에서 ApiResponse로 변경됨
- LoginFilter content type 변경, URI 변경